### PR TITLE
Fix import migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-test-onerror-codemod",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "test": "codemod-cli test",
     "update-docs": "codemod-cli update-docs"

--- a/transforms/remove-onerror-sinon-stubs/__testfixtures__/skip-import.input.js
+++ b/transforms/remove-onerror-sinon-stubs/__testfixtures__/skip-import.input.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+
+module('foo', function() {
+  test('foo test', async function(assert) {
+    assert.expect(1);
+
+    sinon.stub(Ember, 'foo', function() {});
+    sinon.stub(Ember, 'foo', () => {});
+    sinon.stub(Ember, 'foo', fn);
+  });
+});

--- a/transforms/remove-onerror-sinon-stubs/__testfixtures__/skip-import.output.js
+++ b/transforms/remove-onerror-sinon-stubs/__testfixtures__/skip-import.output.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+
+module('foo', function() {
+  test('foo test', async function(assert) {
+    assert.expect(1);
+
+    sinon.stub(Ember, 'foo', function() {});
+    sinon.stub(Ember, 'foo', () => {});
+    sinon.stub(Ember, 'foo', fn);
+  });
+});

--- a/transforms/remove-onerror-sinon-stubs/index.js
+++ b/transforms/remove-onerror-sinon-stubs/index.js
@@ -4,6 +4,7 @@ const { addImportStatement, writeImportStatements } = require('../utils');
 module.exports = function transformer(file, api) {
   const j = getParser(api);
   const root = j(file.source);
+  let requiresImport = false;
 
   const replacer = path => {
     let node = path.node;
@@ -15,6 +16,7 @@ module.exports = function transformer(file, api) {
       return node;
     }
 
+    requiresImport = true;
     return j.callExpression(j.identifier('setupOnerror'), [onErrorFn]);
   };
 
@@ -33,8 +35,11 @@ module.exports = function transformer(file, api) {
 
   if (replacements.length > 0) {
     replacements.replaceWith(replacer);
-    addImportStatement(['setupOnerror']);
-    writeImportStatements(j, root);
+
+    if (requiresImport) {
+      addImportStatement(['setupOnerror']);
+      writeImportStatements(j, root);
+    }
   }
 
   return root.toSource({ quote: 'single' });


### PR DESCRIPTION
Currently, it was possible to get false positives due to the loose matching employed by the `find`.